### PR TITLE
fix parameterless run

### DIFF
--- a/PythonEmbed4Win.ps1
+++ b/PythonEmbed4Win.ps1
@@ -80,7 +80,7 @@
 .NOTES
     Author: James Thomas Moon
 #>
-[Cmdletbinding()]
+[Cmdletbinding(DefaultParameterSetName = 'Install')]
 Param (
     [Parameter(ParameterSetName = 'Install')]
     [System.IO.FileInfo] $Path,


### PR DESCRIPTION
Commit f0f6f3d breaks the possibility to run the script without parameters. Adding a default parameter set fixes it.